### PR TITLE
Fix docker kubernetes volume /etc/odoo

### DIFF
--- a/docker/Dockerfile.prod.pkg
+++ b/docker/Dockerfile.prod.pkg
@@ -43,6 +43,8 @@ RUN cd $ODOO_PREFIX && \
     ./docker/repo_manifest_gen_org_prefix_path.py $ODOO_PREFIX/addons /etc/odoo/odoo.conf /etc/odoo/odoo.conf && \
     head /etc/odoo/odoo.conf
 
+RUN cp /etc/odoo/odoo.conf /odoo.conf
+
 #RUN mkdir '/home/odoo/.local'
 #RUN chown -R odoo '/home/odoo/.local'
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -42,6 +42,11 @@ then
     exit 1
 fi
 
+# Fix volumes of odoo.conf if not exist
+if [ ! -f "/etc/odoo/odoo.conf" ]; then
+    cp /odoo.conf /etc/odoo/odoo.conf
+fi
+
 # set the postgres database host, port, user and password according to the environment
 # and pass them as arguments to the odoo process if not present in the config file
 : ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}


### PR DESCRIPTION
When set a volume for /etc/odoo in kubernetes, it overwrite /etc/odoo/odoo.conf and the docker cannot start.
This script will copy /etc/odoo/odoo.conf in a temporary place to recopy it when volumes is mounted.